### PR TITLE
Change tracking & Developer api changes

### DIFF
--- a/controllers/developers.js
+++ b/controllers/developers.js
@@ -49,34 +49,26 @@ module.exports = {
 
     update(request, reply) {
         let id = encodeURIComponent(request.params.id);
+        let data = request.payload.data.attributes;
 
         Developer.findById(id, (err, developer) => {
             if (err) {
-                return reply(new Error(err));
+                return reply(err).code(400);
             }
 
             Object.assign(developer, {
-                available: request.payload.available,
-                availableDate: request.payload.availableDate,
-                name: request.payload.name,
-                firstName: request.payload.firstName,
-                lastName: request.payload.lastName,
-                createdAt: request.payload.createdAt,
-                updatedAt: request.payload.updatedAt,
-                profileUrl: request.payload.profileUrl,
-                imageUrl: request.payload.imageUrl,
-                address: request.payload.address,
-                location: request.payload.location,
-                timezone: request.payload.timezone,
-                rate: request.payload.rate,
-                skills: request.payload.skills
+                availableDate: data['available-date'],
+                rate: data.rate
             });
 
-            developer.save((err, developer) => {
-                if (err) {
-                    return reply(new Error(err));
+            developer.save((saveError, developer) => {
+                if (saveError) {
+                    return reply({errors: saveError.errors}).code(400);
                 }
-                return reply(developer);
+
+                let result = jsonApi.mongoosetoJsonApiObject(developer, 'developer');
+                return reply({data: result});
+
             });
         });
     },

--- a/controllers/opportunities.js
+++ b/controllers/opportunities.js
@@ -33,8 +33,8 @@ module.exports = {
         let data = request.payload.data.attributes;
         Opportunity.create({
             name: data.name,
-            dateFrom: data.dateFrom,
-            dateTo: data.dateTo,
+            dateFrom: data['date-from'],
+            dateTo: data['date-to'],
             skills: data.skills
         }, (err, opportunity) => {
             if (err) {
@@ -55,8 +55,8 @@ module.exports = {
             }
             Object.assign(opportunity, {
                 name: data.name,
-                dateFrom: data['date-from'],
                 dateTo: data['date-to'],
+                dateFrom: data['date-from'],
                 skills: data.skills
             });
 

--- a/models/developer.js
+++ b/models/developer.js
@@ -2,18 +2,10 @@
 
 const request = require('request');
 const mongoose = require('mongoose');
-const _ = require('lodash');
-const moment = require('moment');
+const DateChangeTrackingPlugin = require('../plugins/date-change-tracking');
 const Schema = mongoose.Schema;
 
-const AvailableDateSchema = new Schema({
-    version: Number,
-    value: Date,
-    created_at: Date
-});
-
 const DeveloperSchema = new Schema({
-    availableDateHistory: [AvailableDateSchema],
     name: String,
     firstName: String,
     lastName: String,
@@ -32,32 +24,9 @@ const DeveloperSchema = new Schema({
     }
 });
 
-DeveloperSchema
-    .virtual('availableDate')
-    .get(function() {
-        let lastUpdated = _.sortBy(this.availableDateHistory, 'version').pop();
-        if(!lastUpdated) {
-            return null;
-        }
-        return lastUpdated.value;
-    })
-    .set(function(val) {
-        let lastUpdated = _.sortBy(this.availableDateHistory, 'version').pop() || {
-            version: 0,
-            value: null
-        };
-        let valueRemainedEmpty = val === null && lastUpdated.value === null;
-        let valueDidntChange = moment(val).isSame(lastUpdated.value, 'day');
-        if(valueRemainedEmpty || valueDidntChange) {
-            return;
-        }
-        let newVersionNumber = lastUpdated.version + 1;
-        this.availableDateHistory.push({
-            version: newVersionNumber,
-            created_at: new Date(),
-            value: val
-        });
-    });
+DeveloperSchema.plugin(DateChangeTrackingPlugin, {
+    field: 'availableDate'
+});
 
 Object.assign(DeveloperSchema.methods, {
     fetchLocation(address) {

--- a/models/developer.js
+++ b/models/developer.js
@@ -16,7 +16,7 @@ const DeveloperSchema = new Schema({
     address: String,
     location: String,
     timezone: String,
-    rate: String,
+    rate: Number,
     skills: Array
 }, {
     toObject: {
@@ -25,7 +25,7 @@ const DeveloperSchema = new Schema({
 });
 
 DeveloperSchema.plugin(DateChangeTrackingPlugin, {
-    field: 'availableDate'
+    fields: [{field: 'availableDate'}]
 });
 
 Object.assign(DeveloperSchema.methods, {

--- a/models/opportunity.js
+++ b/models/opportunity.js
@@ -3,28 +3,33 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 const timestamps = require('mongoose-timestamp');
+const moment = require('moment');
+const DateChangeTrackingPlugin = require('../plugins/date-change-tracking');
 
 const OpportunitySchema = new Schema({
     name: {
         type: String,
         required: 'Name is required'
     },
-    dateFrom: {
-        type: Date,
-        validate: [earlierThanDateTo, 'Date to must be greater than Date from']
-    },
-    dateTo: Date,
     skills: Array
+}, {
+    toObject: {
+        virtuals: true
+    }
 });
 
 //add createdAt, updatedAt
 OpportunitySchema.plugin(timestamps);
 
+OpportunitySchema.plugin(DateChangeTrackingPlugin, {
+    fields: [
+        {field: 'dateFrom', required: 'Date From is required', validate: [earlierThanDateTo, 'Date to must be greater than Date from']},
+        {field: 'dateTo', required: 'Date To is required'}
+    ]
+});
+
 function earlierThanDateTo(value) {
-    if(value && this.dateTo && value > this.dateTo) {
-        return false;
-    }
-    return true;
+    return moment(value).isBefore(this.dateTo);
 }
 
 module.exports = mongoose.model('Opportunity', OpportunitySchema);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "hapi-auth-jwt": "^4.0.0",
     "jsonwebtoken": "^5.5.4",
     "kerberos": "0.0.17",
+    "lodash": "^4.0.0",
+    "moment": "^2.11.1",
     "mongodb": "^2.0.49",
     "mongoose": "^4.2.8",
     "mongoose-timestamp": "^0.4.0",

--- a/plugins/date-change-tracking.js
+++ b/plugins/date-change-tracking.js
@@ -27,14 +27,23 @@ module.exports = function lastModifiedPlugin (schema, options) {
                 return lastUpdated.value;
             })
             .set(function(val) {
+                //validation checkings
                 if(!val && fieldObj.required) {
                     return this.invalidate(fieldObj.field, fieldObj.required);
                 }
+                if(fieldObj.validate) {
+                    let validate = fieldObj.validate[0];
+                    if(!validate.apply(this, [val])) {
+                        return this.invalidate(fieldObj.field, fieldObj.validate[1]);
+                    }
+                }
+
                 let historyField = this[historyLocation];
                 let lastUpdated = _.sortBy(historyField, 'version').pop() || {
                     version: 0,
                     value: null
                 };
+
                 let valueRemainedEmpty = val === null && lastUpdated.value === null;
                 let valueDidntChange = moment(val).isSame(lastUpdated.value, 'day');
                 if(valueRemainedEmpty || valueDidntChange) {

--- a/plugins/date-change-tracking.js
+++ b/plugins/date-change-tracking.js
@@ -19,12 +19,7 @@ module.exports = function lastModifiedPlugin (schema, options) {
 
         schema.virtual(fieldObj.field)
             .get(function() {
-                let historyField = this[historyLocation];
-                let lastUpdated = _.sortBy(historyField, 'version').pop();
-                if(!lastUpdated) {
-                    return null;
-                }
-                return lastUpdated.value;
+                return _.chain(this[historyLocation]).sortBy('version').last().get('value').value() || null;
             })
             .set(function(val) {
                 //validation checkings
@@ -44,14 +39,13 @@ module.exports = function lastModifiedPlugin (schema, options) {
                     value: null
                 };
 
-                let valueRemainedEmpty = val === null && lastUpdated.value === null;
-                let valueDidntChange = moment(val).isSame(lastUpdated.value, 'day');
-                if(valueRemainedEmpty || valueDidntChange) {
+                let dateRemainedEmpty = val === null && lastUpdated.value === null;
+                let dateDidntChange = moment(val).isSame(lastUpdated.value, 'day');
+                if(dateRemainedEmpty || dateDidntChange) {
                     return;
                 }
-                let newVersionNumber = lastUpdated.version + 1;
                 historyField.push({
-                    version: newVersionNumber,
+                    version: lastUpdated.version + 1,
                     created_at: new Date(),
                     value: val
                 });

--- a/plugins/date-change-tracking.js
+++ b/plugins/date-change-tracking.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const _ = require('lodash');
+const moment = require('moment');
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const ChangeTrackDateSchema = new Schema({
+    version: Number,
+    value: Date,
+    created_at: Date
+});
+
+module.exports = function lastModifiedPlugin (schema, options) {
+    let historyLocation = `${options.field}History`
+    schema.add({[historyLocation]: [ChangeTrackDateSchema]});
+    schema.virtual(options.field)
+    .get(function() {
+        let lastUpdated = _.sortBy(this.availableDateHistory, 'version').pop();
+        if(!lastUpdated) {
+            return null;
+        }
+        return lastUpdated.value;
+    })
+    .set(function(val) {
+        let lastUpdated = _.sortBy(this.availableDateHistory, 'version').pop() || {
+            version: 0,
+            value: null
+        };
+        let valueRemainedEmpty = val === null && lastUpdated.value === null;
+        let valueDidntChange = moment(val).isSame(lastUpdated.value, 'day');
+        if(valueRemainedEmpty || valueDidntChange) {
+            return;
+        }
+        let newVersionNumber = lastUpdated.version + 1;
+        this.availableDateHistory.push({
+            version: newVersionNumber,
+            created_at: new Date(),
+            value: val
+        });
+    });
+};


### PR DESCRIPTION
Issue related: #15 

The bulk of this pull request was creating a mongoose plugin `date-change-tracking.js` that creates a nested object for saving the change history for the fields provided, and it makes a virtual field that through it you will insert/retrieve data from the history collection 

- Add update developers api